### PR TITLE
✨Implement support for versioning

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "registry": "https://www.npmjs.com"
   },
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "This repository uses the local file system to access and manipulate log files.",
   "license": "MIT",
   "main": "dist/commonjs/index.js",

--- a/package.json
+++ b/package.json
@@ -1,18 +1,25 @@
 {
   "name": "@process-engine/logging.repository.file_system",
-  "publishConfig": {
-    "registry": "https://www.npmjs.com"
-  },
   "version": "1.3.0",
-  "description": "This repository uses the local file system to access and manipulate log files.",
-  "license": "MIT",
+  "description": "Contains the file-system repository for the Metrics API. ",
   "main": "dist/commonjs/index.js",
   "typings": "dist/index.d.ts",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/process-engine/metrics.repository.file_system.git"
+  },
   "author": "5Minds IT-Solutions GmbH & Co. KG",
-  "contributors": [
-    "Sebastian Meier <sebastian.meier@5minds.de>",
-    "Christian Werner <christian.werner@5minds.de>"
+  "maintainers": [
+    "Alexander Kasten <alexander.kasten@5minds.de>",
+    "Christian Werner <christian.werner@5minds.de>",
+    "René Föhring <rene.foehring@5minds.de>",
+    "Steffen Knaup <steffen.knaup@5minds.de>"
   ],
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/process-engine/metrics.repository.file_system/issues"
+  },
+  "homepage": "https://github.com/process-engine/metrics.repository.file_system#readme",
   "dependencies": {
     "@process-engine/logging_api_contracts": "^1.0.0",
     "moment": "^2.24.0"

--- a/src/adapter/file_system_adapter.ts
+++ b/src/adapter/file_system_adapter.ts
@@ -1,20 +1,15 @@
-import {LogEntry, LogLevel} from '@process-engine/logging_api_contracts';
-
 import * as fs from 'fs';
 import * as mkdirp from 'mkdirp';
-import * as moment from 'moment';
 import * as path from 'path';
+
+import {LogEntry} from '@process-engine/logging_api_contracts';
+
+import {parseLogEntry} from './parser/parser';
 
 export function targetExists(targetPath: string): boolean {
   return fs.existsSync(targetPath);
 }
 
-/**
- * Checks if the given path exists and creates it, if it doesn't.
- *
- * @async
- * @param targetFilePath The directory to verify.
- */
 export async function ensureDirectoryExists(targetFilePath: string): Promise<void> {
 
   // eslint-disable-next-line consistent-return
@@ -23,7 +18,6 @@ export async function ensureDirectoryExists(targetFilePath: string): Promise<voi
     const parsedPath = path.parse(targetFilePath);
 
     const targetDirectoryExists = fs.existsSync(parsedPath.dir);
-
     if (targetDirectoryExists) {
       return resolve();
     }
@@ -39,13 +33,6 @@ export async function ensureDirectoryExists(targetFilePath: string): Promise<voi
   });
 }
 
-/**
- * Writes the given entry to the specificed log file.
- *
- * @async
- * @param targetFilePath The path to the file to write to.
- * @param entry          The entry to write into the file.
- */
 export async function writeToLogFile(targetFilePath: string, entry: string): Promise<void> {
 
   return new Promise<void>((resolve: Function, reject: Function): void => {
@@ -58,13 +45,6 @@ export async function writeToLogFile(targetFilePath: string, entry: string): Pro
   });
 }
 
-/**
- * Reads all files from the given directory and parses their content into
- * readable LogEntries.
- *
- * @param dirPath The path to the directory to read.
- * @returns       The parsed logs.
- */
 export function readAndParseDirectory(dirPath: string): Array<LogEntry> {
 
   const logfileNames = fs.readdirSync(dirPath);
@@ -80,13 +60,6 @@ export function readAndParseDirectory(dirPath: string): Array<LogEntry> {
   return correlationLogs;
 }
 
-/**
- * Reads a file from the given path and parses its content into a readable
- * LogEntry.
- *
- * @param   filePath The path to the file to read.
- * @returns          The parsed log.
- */
 export function readAndParseFile(filePath: string): Array<LogEntry> {
 
   const logFileContent = fs.readFileSync(filePath, 'utf-8');
@@ -98,68 +71,7 @@ export function readAndParseFile(filePath: string): Array<LogEntry> {
     return entry.length > 0;
   });
 
-  const logEntries = logEntriesFiltered.map(createLogEntryFromRawData);
+  const logEntries = logEntriesFiltered.map(parseLogEntry);
 
   return logEntries;
-}
-
-/**
- * Takes a string representing a log entry and parses its content into a usable
- * LogEntry object.
- *
- * @param   logEntryRaw The string containing the unparsed log entry.
- * @returns             The parsed LogEntry.
- */
-// tslint:disable:no-magic-numbers
-function createLogEntryFromRawData(logEntryRaw: string): LogEntry {
-
-  const logEntryRawParts = logEntryRaw.split(';');
-
-  const isFlowNodeInstanceLog = logEntryRawParts[0] === 'FlowNodeInstance';
-
-  const logEntry = isFlowNodeInstanceLog
-    ? parseFlowNodeInstanceLog(logEntryRawParts)
-    : parseProcessModelLog(logEntryRawParts);
-
-  return logEntry;
-}
-
-/**
- * Creates a LogEntry for a FlowNodeInstance from the given data.
- *
- * @param   rawData The data to parse into a LogEntry.
- * @returns         The parsed LogEntry.
- */
-function parseFlowNodeInstanceLog(rawData: Array<string>): LogEntry {
-
-  const logEntry = new LogEntry();
-  logEntry.timeStamp = moment(rawData[1]).toDate();
-  logEntry.correlationId = rawData[2];
-  logEntry.processModelId = rawData[3];
-  logEntry.processInstanceId = rawData[4];
-  logEntry.flowNodeInstanceId = rawData[5];
-  logEntry.flowNodeId = rawData[6];
-  logEntry.logLevel = LogLevel[rawData[7]];
-  logEntry.message = rawData[8];
-
-  return logEntry;
-}
-
-/**
- * Creates a LogEntry for a ProcessModel from the given data.
- *
- * @param   rawData The data to parse into a LogEntry.
- * @returns         The parsed LogEntry.
- */
-function parseProcessModelLog(rawData: Array<string>): LogEntry {
-
-  const logEntry = new LogEntry();
-  logEntry.timeStamp = moment(rawData[1]).toDate();
-  logEntry.correlationId = rawData[2];
-  logEntry.processModelId = rawData[3];
-  logEntry.processInstanceId = rawData[4];
-  logEntry.logLevel = LogLevel[rawData[7]];
-  logEntry.message = rawData[8];
-
-  return logEntry;
 }

--- a/src/adapter/parser/flow_node_log_parser.ts
+++ b/src/adapter/parser/flow_node_log_parser.ts
@@ -1,0 +1,23 @@
+import * as moment from 'moment';
+
+import {LogEntry, LogLevel} from '@process-engine/logging_api_contracts';
+
+export function parseFlowNodeInstanceLog(logData: Array<string>): LogEntry {
+
+  return parseAsV1(logData);
+}
+
+function parseAsV1(logData: Array<string>): LogEntry {
+
+  const logEntry = new LogEntry();
+  logEntry.timeStamp = moment(logData[1]).toDate();
+  logEntry.correlationId = logData[2];
+  logEntry.processModelId = logData[3];
+  logEntry.processInstanceId = logData[4];
+  logEntry.flowNodeInstanceId = logData[5];
+  logEntry.flowNodeId = logData[6];
+  logEntry.logLevel = LogLevel[logData[7]];
+  logEntry.message = logData[8];
+
+  return logEntry;
+}

--- a/src/adapter/parser/parser.ts
+++ b/src/adapter/parser/parser.ts
@@ -1,0 +1,17 @@
+import {LogEntry} from '@process-engine/logging_api_contracts';
+
+import {parseFlowNodeInstanceLog} from './flow_node_log_parser';
+import {parseProcessModelLog} from './process_model_log_parser';
+
+export function parseLogEntry(logEntryRaw: string): LogEntry {
+
+  const logEntryRawParts = logEntryRaw.split(';');
+
+  const isFlowNodeInstanceLog = logEntryRawParts[0] === 'FlowNodeInstance';
+
+  const logEntry = isFlowNodeInstanceLog
+    ? parseFlowNodeInstanceLog(logEntryRawParts)
+    : parseProcessModelLog(logEntryRawParts);
+
+  return logEntry;
+}

--- a/src/adapter/parser/process_model_log_parser.ts
+++ b/src/adapter/parser/process_model_log_parser.ts
@@ -1,0 +1,21 @@
+import * as moment from 'moment';
+
+import {LogEntry, LogLevel} from '@process-engine/logging_api_contracts';
+
+export function parseProcessModelLog(logData: Array<string>): LogEntry {
+
+  return parseAsV1(logData);
+}
+
+function parseAsV1(logData: Array<string>): LogEntry {
+
+  const logEntry = new LogEntry();
+  logEntry.timeStamp = moment(logData[1]).toDate();
+  logEntry.correlationId = logData[2];
+  logEntry.processModelId = logData[3];
+  logEntry.processInstanceId = logData[4];
+  logEntry.logLevel = LogLevel[logData[7]];
+  logEntry.message = logData[8];
+
+  return logEntry;
+}

--- a/src/logging_repository.ts
+++ b/src/logging_repository.ts
@@ -36,7 +36,18 @@ export class LoggingRepository implements ILoggingRepository {
 
     const timeStampAsIsoString = moment(timestamp).toISOString();
 
-    const logEntryValues = ['ProcessModel', timeStampAsIsoString, correlationId, processModelId, processInstanceId, '', '', logLevel, message];
+    const logEntryValues = [
+      'ProcessModel',
+      timeStampAsIsoString,
+      correlationId,
+      processModelId,
+      processInstanceId,
+      '',
+      '',
+      logLevel,
+      message,
+    ];
+
     await this.writeLogEntryToFileSystem(processModelId, ...logEntryValues);
   }
 
@@ -53,8 +64,18 @@ export class LoggingRepository implements ILoggingRepository {
 
     const timeStampAsIsoString = moment(timestamp).toISOString();
 
-    const logEntryValues =
-      ['FlowNodeInstance', timeStampAsIsoString, correlationId, processModelId, processInstanceId, flowNodeInstanceId, flowNodeId, logLevel, message];
+    const logEntryValues = [
+      'FlowNodeInstance',
+      timeStampAsIsoString,
+      correlationId,
+      processModelId,
+      processInstanceId,
+      flowNodeInstanceId,
+      flowNodeId,
+      logLevel,
+      message,
+    ];
+
     await this.writeLogEntryToFileSystem(processModelId, ...logEntryValues);
   }
 


### PR DESCRIPTION
## Changes

1. Implement support for versioning
    - This is achieved through dedicated log parsers; one for each type
    - Each parser is able to handle different versions of a log
    - The prefix applied to each log will determine its version
    - The FileSystemAdapter no longer needs to know anything about the format of the logs in order to get a parsed result
2. Add author and maintainer info

## Issues

Part of https://github.com/process-engine/process_engine_runtime/issues/367

PR: #4